### PR TITLE
Reenabled verification workflow for OSX

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,0 +1,46 @@
+name: OSX build
+on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash -e -l {0}
+jobs:
+  build:
+    runs-on: macos-${{ matrix.os }}
+    name: macos-${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - 14
+        - 15
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set conda environment
+      uses: mamba-org/setup-micromamba@main
+      with:
+        environment-name: myenv
+        environment-file: environment-dev.yml
+        init-shell: bash
+        cache-downloads: true
+
+    - name: Configure using CMake
+      run: cmake -B build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DBUILD_TESTS=ON
+
+    - name: Install
+      working-directory: build
+      run: cmake --install .
+
+    - name: Build
+      working-directory: build
+      run: cmake --build . --target test_xsimd_algorithm --parallel 8
+
+    - name: Run tests
+      working-directory: build/test
+      run: ./test_xsimd_algorithm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 # =====
 
 set(XSIMDALGO_HEADERS
-    ${XSIMDALGO_INCLUDE_DIR}/xsimd_algo/algorithms.hpp
+    ${XSIMDALGO_INCLUDE_DIR}/xsimd_algorithm/algorithms.hpp
 )
 
 add_library(xsimd-algorithm INTERFACE)
@@ -56,7 +56,7 @@ install(TARGETS xsimd-algorithm
 export(EXPORT ${PROJECT_NAME}-targets
        FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
 
-install(DIRECTORY ${XSIMDALGO_INCLUDE_DIR}/xsimd_algo
+install(DIRECTORY ${XSIMDALGO_INCLUDE_DIR}/xsimd_algorithm
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 set(XSIMDALGO_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}" CACHE


### PR DESCRIPTION
Re-enablement of OSX github actions workflow.

As OSX 13 runner is retired it was excluded from the configuration matrix.